### PR TITLE
Complete returning-volunteer engagement agent MVP

### DIFF
--- a/serve-engagement-agent-service/app/clients/domain_client.py
+++ b/serve-engagement-agent-service/app/clients/domain_client.py
@@ -101,6 +101,66 @@ class DomainClient:
             "data": data or {},
         })
 
+    # ── Volunteer Context ─────────────────────────────────────────────────────
+
+    async def get_engagement_context(self, volunteer_id: str) -> Dict:
+        """Load fulfillment history, active nominations, and profile for engagement."""
+        return await _call_mcp_tool("get_engagement_context", {"volunteer_id": volunteer_id})
+
+    async def engagement_save_confirmed_signals(self, session_id: str, signals: Dict[str, Any]) -> Dict:
+        """Persist confirmed engagement signals in MCP-managed session state."""
+        return await _call_mcp_tool("engagement_save_confirmed_signals", {
+            "session_id": session_id,
+            "signals": signals,
+        })
+
+    async def engagement_update_volunteer_status(
+        self,
+        session_id: str,
+        volunteer_status: str,
+        reason: Optional[str] = None,
+        signals: Optional[Dict[str, Any]] = None,
+    ) -> Dict:
+        """Persist engagement status in MCP-managed session state."""
+        args: Dict[str, Any] = {
+            "session_id": session_id,
+            "volunteer_status": volunteer_status,
+        }
+        if reason:
+            args["reason"] = reason
+        if signals:
+            args["signals"] = signals
+        return await _call_mcp_tool("engagement_update_volunteer_status", args)
+
+    async def engagement_prepare_fulfillment_handoff(
+        self,
+        session_id: str,
+        signals: Optional[Dict[str, Any]] = None,
+    ) -> Dict:
+        """Build the fulfillment handoff payload for the engagement session."""
+        args: Dict[str, Any] = {"session_id": session_id}
+        if signals:
+            args["signals"] = signals
+        return await _call_mcp_tool("engagement_prepare_fulfillment_handoff", args)
+
+    async def save_memory_summary(
+        self,
+        session_id: str,
+        summary_text: str,
+        key_facts: Optional[list] = None,
+        volunteer_id: Optional[str] = None,
+    ) -> Dict:
+        """Persist a summary using the generic MCP memory tool."""
+        args: Dict[str, Any] = {
+            "session_id": session_id,
+            "summary_text": summary_text,
+        }
+        if key_facts is not None:
+            args["key_facts"] = key_facts
+        if volunteer_id:
+            args["volunteer_id"] = volunteer_id
+        return await _call_mcp_tool("save_memory_summary", args)
+
     # ── Volunteer Profile ─────────────────────────────────────────────────────
 
     async def get_volunteer_profile(self, session_id: str) -> Dict:

--- a/serve-engagement-agent-service/app/schemas/engagement_schemas.py
+++ b/serve-engagement-agent-service/app/schemas/engagement_schemas.py
@@ -3,31 +3,52 @@ SERVE Engagement Agent Service - Schemas
 
 Workflow stages for returning volunteer re-engagement:
 
-  RE_ENGAGING        — Warm welcome back, confirm identity, surface last activity
-  PROFILE_REFRESH    — Check if skills/availability have changed since last session
-  MATCHING_READY     — Profile is current, hand off to matching agent
+  RE_ENGAGING        — Warm welcome back and confirm whether they want to continue
+  PROFILE_REFRESH    — Capture continuity preferences before downstream routing
+  MATCHING_READY     — Legacy compatibility stage for handoff preparation
+  HUMAN_REVIEW       — Sensitive / declined / ambiguous case
   PAUSED             — Volunteer wants to continue later
-
-TODO (contributor): Add more stages as the engagement flow is designed.
-  e.g. PREFERENCE_UPDATE, COMMITMENT_CONFIRMATION, SCHEDULING, etc.
 """
-from typing import Any, Dict, List, Optional
+import json
+import logging
+from typing import Any, Dict, List, Literal, Optional
 from uuid import UUID
 from pydantic import BaseModel, Field
 from enum import Enum
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_SUB_STATE = {
+    "engagement_context": {},
+    "continue_decision": None,
+    "same_school": None,
+    "same_slot": None,
+    "open_to_alternatives": None,
+    "continuity": None,
+    "preference_notes": None,
+    "handoff": {},
+    "human_review_reason": None,
+}
 
 
 class EngagementWorkflowState(str, Enum):
     """Stages in the returning-volunteer engagement workflow."""
     RE_ENGAGING     = "re_engaging"      # Initial re-contact, identity confirmation
-    PROFILE_REFRESH = "profile_refresh"  # Checking for profile updates
-    MATCHING_READY  = "matching_ready"   # Ready to hand off to matching agent
+    PROFILE_REFRESH = "profile_refresh"  # Capturing continuity preferences
+    MATCHING_READY  = "matching_ready"   # Legacy handoff-prep stage
+    HUMAN_REVIEW    = "human_review"     # Needs human follow-up or manual handling
     PAUSED          = "paused"           # Volunteer paused the session
 
-    # TODO: add more stages here as the flow is designed
-    # PREFERENCE_UPDATE     = "preference_update"
-    # COMMITMENT_CONFIRM    = "commitment_confirm"
-    # SCHEDULING            = "scheduling"
+
+class FulfillmentHandoffPayload(BaseModel):
+    """Payload shape expected by the fulfillment agent."""
+    volunteer_id: str
+    volunteer_name: str
+    continuity: Literal["same", "different"]
+    preferred_need_id: Optional[str] = None
+    preferred_school_id: Optional[str] = None
+    preference_notes: Optional[str] = None
+    fulfillment_history: List[Dict[str, Any]] = Field(default_factory=list)
 
 
 class EngagementSessionState(BaseModel):
@@ -71,3 +92,42 @@ class EngagementAgentTurnResponse(BaseModel):
     # Telemetry
     telemetry_events: List[Dict[str, Any]] = Field(default_factory=list)
     handoff_event: Optional[Dict[str, Any]] = None
+
+
+def _load_sub_state(raw: Optional[str]) -> Dict[str, Any]:
+    """Load sub_state from JSON string, defaulting on missing/malformed input."""
+    if not raw:
+        return dict(_DEFAULT_SUB_STATE)
+    try:
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            return dict(_DEFAULT_SUB_STATE)
+        return {
+            "engagement_context": data.get("engagement_context", {}),
+            "continue_decision": data.get("continue_decision"),
+            "same_school": data.get("same_school"),
+            "same_slot": data.get("same_slot"),
+            "open_to_alternatives": data.get("open_to_alternatives"),
+            "continuity": data.get("continuity"),
+            "preference_notes": data.get("preference_notes"),
+            "handoff": data.get("handoff", {}),
+            "human_review_reason": data.get("human_review_reason"),
+        }
+    except (json.JSONDecodeError, ValueError):
+        logger.warning("Malformed engagement sub_state JSON — using defaults")
+        return dict(_DEFAULT_SUB_STATE)
+
+
+def _dump_sub_state(sub_state: Dict[str, Any]) -> str:
+    """Serialize engagement sub_state to JSON string."""
+    return json.dumps({
+        "engagement_context": sub_state.get("engagement_context", {}),
+        "continue_decision": sub_state.get("continue_decision"),
+        "same_school": sub_state.get("same_school"),
+        "same_slot": sub_state.get("same_slot"),
+        "open_to_alternatives": sub_state.get("open_to_alternatives"),
+        "continuity": sub_state.get("continuity"),
+        "preference_notes": sub_state.get("preference_notes"),
+        "handoff": sub_state.get("handoff", {}),
+        "human_review_reason": sub_state.get("human_review_reason"),
+    })

--- a/serve-engagement-agent-service/app/service/engagement_logic.py
+++ b/serve-engagement-agent-service/app/service/engagement_logic.py
@@ -1,157 +1,635 @@
 """
 SERVE Engagement Agent Service - Core Logic
 
-State machine for returning volunteer re-engagement.
-Same architectural pattern as need_logic.py.
-
-Current stages (boilerplate — expand as needed):
-  RE_ENGAGING     → greet returning volunteer, confirm identity
-  PROFILE_REFRESH → check if skills/availability changed
-  MATCHING_READY  → profile confirmed, ready for matching handoff
-  PAUSED          → volunteer paused
-
-TODO (contributor):
-  - Implement _handle_re_engaging: fetch volunteer profile from MCP, greet by name
-  - Implement _handle_profile_refresh: surface current profile, ask for updates
-  - Implement _handle_matching_ready: trigger matching agent handoff
-  - Add new stages as the engagement flow is designed
+MVP engagement flow for recommended-but-not-utilised or returning volunteers:
+1. Re-engage and confirm whether they want to continue
+2. Capture continuity preferences (same school / same slot / alternatives)
+3. Hand off ready volunteers to fulfillment
+4. Pause or human-review the rest
 """
 import logging
-from typing import Any, Dict, Optional
+import re
+from typing import Any, Dict, List, Optional
 
 from app.schemas.engagement_schemas import (
     EngagementWorkflowState,
     EngagementAgentTurnRequest,
     EngagementAgentTurnResponse,
+    FulfillmentHandoffPayload,
+    _dump_sub_state,
+    _load_sub_state,
 )
 from app.clients.domain_client import domain_client
-from app.service.llm_adapter import llm_adapter
 
 logger = logging.getLogger(__name__)
 
+_TERMINAL_MESSAGES = {
+    EngagementWorkflowState.HUMAN_REVIEW.value: (
+        "Thanks for sharing honestly. We'll update your preference and a team member can follow up if needed."
+    ),
+    EngagementWorkflowState.PAUSED.value: (
+        "No problem. We'll reconnect later, and you can come back whenever you're ready."
+    ),
+}
+
+_DEFER_PATTERNS = [
+    r"\bnot now\b",
+    r"\bnot available\b",
+    r"\blater\b",
+    r"\bmaybe later\b",
+    r"\bnot sure\b",
+    r"\bbusy\b",
+    r"\bunavailable\b",
+    r"\bcurrently unavailable\b",
+    r"\bnext term\b",
+    r"\bnext year\b",
+    r"\babhi nahi\b",
+    r"\bbaad mein\b",
+]
+
+_DECLINE_PATTERNS = [
+    r"\bno\b",
+    r"\bnope\b",
+    r"\bnot interested\b",
+    r"\bdon't contact\b",
+    r"\bdo not contact\b",
+    r"\bopt out\b",
+    r"\bstop\b",
+    r"\bcannot continue\b",
+    r"\bcan't continue\b",
+    r"\bnahi\b",
+    r"\bnahin\b",
+]
+
+_CONTINUE_PATTERNS = [
+    r"\byes\b",
+    r"\bhaan\b",
+    r"\bhan\b",
+    r"\bcontinue\b",
+    r"\bready\b",
+    r"\binterested\b",
+    r"\bavailable\b",
+    r"\bstart\b",
+    r"\bkeep going\b",
+]
+
+_SAME_SCHOOL_PATTERNS = [
+    r"\bsame school\b",
+    r"\bsame place\b",
+    r"\bsame as before\b",
+    r"\busi school\b",
+]
+
+_FLEX_SCHOOL_PATTERNS = [
+    r"\bdifferent school\b",
+    r"\bany school\b",
+    r"\bflexible school\b",
+    r"\bopen to another school\b",
+    r"\bopen to a different school\b",
+    r"\bkahi bhi\b",
+]
+
+_SAME_SLOT_PATTERNS = [
+    r"\bsame slot\b",
+    r"\bsame time\b",
+    r"\bsame timing\b",
+    r"\bsame schedule\b",
+    r"\bsame days\b",
+    r"\bussi timing\b",
+]
+
+_FLEX_SLOT_PATTERNS = [
+    r"\bflexible slot\b",
+    r"\bflexible timing\b",
+    r"\bany time\b",
+    r"\bdifferent time\b",
+    r"\bchange time\b",
+    r"\bopen timing\b",
+    r"\bflexible on timing\b",
+]
+
+_ALTERNATIVE_PATTERNS = [
+    r"\bopen to alternatives\b",
+    r"\bopen to options\b",
+    r"\bfully flexible\b",
+    r"\bany option\b",
+]
+
 
 class EngagementAgentService:
-    """
-    Engagement agent state machine.
-    Each stage handler receives the request and returns a response.
-    """
+    """MVP engagement state machine for volunteer continuity."""
 
     async def process_turn(self, request: EngagementAgentTurnRequest) -> EngagementAgentTurnResponse:
         stage = request.session_state.stage
+        sub_state = _load_sub_state(request.session_state.sub_state)
 
+        await self._ensure_context_loaded(request, sub_state)
+
+        if stage == EngagementWorkflowState.HUMAN_REVIEW.value:
+            return self._build_response(
+                message=_TERMINAL_MESSAGES[EngagementWorkflowState.HUMAN_REVIEW.value],
+                next_state=EngagementWorkflowState.HUMAN_REVIEW.value,
+                sub_state=sub_state,
+            )
+
+        #TODO: Consider moving this out of this function
         dispatch = {
-            EngagementWorkflowState.RE_ENGAGING.value:     self._handle_re_engaging,
+            EngagementWorkflowState.RE_ENGAGING.value: self._handle_re_engaging,
             EngagementWorkflowState.PROFILE_REFRESH.value: self._handle_profile_refresh,
-            EngagementWorkflowState.MATCHING_READY.value:  self._handle_matching_ready,
-            EngagementWorkflowState.PAUSED.value:          self._handle_paused,
+            EngagementWorkflowState.MATCHING_READY.value: self._handle_matching_ready,
+            EngagementWorkflowState.PAUSED.value: self._handle_paused,
         }
 
         handler = dispatch.get(stage, self._handle_fallback)
-        return await handler(request)
+        return await handler(request, sub_state)
 
-    # ── Stage handlers ────────────────────────────────────────────────────────
+    async def _handle_re_engaging(
+        self,
+        request: EngagementAgentTurnRequest,
+        sub_state: Dict[str, Any],
+    ) -> EngagementAgentTurnResponse:
+        signals = self._extract_signals(request.user_message)
+        self._merge_signals(sub_state, signals)
+        await self._persist_signals(str(request.session_id), sub_state)
 
-    async def _handle_re_engaging(self, request: EngagementAgentTurnRequest) -> EngagementAgentTurnResponse:
-        """
-        Welcome the volunteer back and confirm their identity.
+        decision = sub_state.get("continue_decision")
+        if decision == "decline":
+            return await self._handle_decline(request, sub_state)
+        if decision == "defer":
+            return await self._handle_defer(request, sub_state)
+        if decision == "continue":
+            missing = self._get_missing_preference_fields(sub_state)
+            if missing:
+                return self._build_response(
+                    message=self._build_preference_question(sub_state),
+                    next_state=EngagementWorkflowState.PROFILE_REFRESH.value,
+                    sub_state=sub_state,
+                    completion_status="collecting_preferences",
+                    confirmed_fields=self._confirmed_fields(sub_state),
+                )
+            return await self._build_fulfillment_handoff_response(request, sub_state)
 
-        TODO (contributor):
-          1. Call domain_client.get_volunteer_profile(session_id) to fetch profile
-          2. Surface their last activity (school, subject, grade) in the greeting
-          3. Detect if they want to continue or update their profile
-          4. Transition to PROFILE_REFRESH or MATCHING_READY accordingly
-        """
-        volunteer_ctx = {
-            "volunteer_name": request.session_state.volunteer_name,
-            "last_active_at": request.session_state.last_active_at,
-        }
-        msg = await llm_adapter.generate_response(
-            stage="re_engaging",
-            messages=request.conversation_history,
-            user_message=request.user_message,
-            volunteer_context=volunteer_ctx,
-        )
         return self._build_response(
-            message=msg,
+            message=self._build_reengagement_prompt(request, sub_state),
             next_state=EngagementWorkflowState.RE_ENGAGING.value,
-            request=request,
+            sub_state=sub_state,
+            completion_status="awaiting_interest",
+            confirmed_fields=self._confirmed_fields(sub_state),
         )
 
-    async def _handle_profile_refresh(self, request: EngagementAgentTurnRequest) -> EngagementAgentTurnResponse:
-        """
-        Check if the volunteer's profile needs updating.
+    async def _handle_profile_refresh(
+        self,
+        request: EngagementAgentTurnRequest,
+        sub_state: Dict[str, Any],
+    ) -> EngagementAgentTurnResponse:
+        signals = self._extract_signals(request.user_message)
+        self._merge_signals(sub_state, signals)
+        await self._persist_signals(str(request.session_id), sub_state)
 
-        TODO (contributor):
-          1. Fetch current profile from domain_client.get_volunteer_profile()
-          2. Show current skills/availability and ask for confirmation or changes
-          3. Save any updates via domain_client.save_volunteer_fields()
-          4. Transition to MATCHING_READY when profile is confirmed
-        """
-        msg = await llm_adapter.generate_response(
-            stage="profile_refresh",
-            messages=request.conversation_history,
-            user_message=request.user_message,
-        )
+        decision = sub_state.get("continue_decision")
+        if decision == "decline":
+            return await self._handle_decline(request, sub_state)
+        if decision == "defer":
+            return await self._handle_defer(request, sub_state)
+        if decision != "continue":
+            return self._build_response(
+                message=self._build_reengagement_prompt(request, sub_state),
+                next_state=EngagementWorkflowState.RE_ENGAGING.value,
+                sub_state=sub_state,
+                completion_status="awaiting_interest",
+                confirmed_fields=self._confirmed_fields(sub_state),
+            )
+
+        missing = self._get_missing_preference_fields(sub_state)
+        if missing:
+            return self._build_response(
+                message=self._build_preference_question(sub_state),
+                next_state=EngagementWorkflowState.PROFILE_REFRESH.value,
+                sub_state=sub_state,
+                completion_status="collecting_preferences",
+                confirmed_fields=self._confirmed_fields(sub_state),
+            )
+
+        return await self._build_fulfillment_handoff_response(request, sub_state)
+
+    async def _handle_matching_ready(
+        self,
+        request: EngagementAgentTurnRequest,
+        sub_state: Dict[str, Any],
+    ) -> EngagementAgentTurnResponse:
+        if sub_state.get("handoff"):
+            return await self._build_fulfillment_handoff_response(request, sub_state)
+        return await self._handle_profile_refresh(request, sub_state)
+
+    async def _handle_paused(
+        self,
+        request: EngagementAgentTurnRequest,
+        sub_state: Dict[str, Any],
+    ) -> EngagementAgentTurnResponse:
+        if request.user_message.strip():
+            return await self._handle_re_engaging(request, sub_state)
         return self._build_response(
-            message=msg,
-            next_state=EngagementWorkflowState.PROFILE_REFRESH.value,
-            request=request,
-        )
-
-    async def _handle_matching_ready(self, request: EngagementAgentTurnRequest) -> EngagementAgentTurnResponse:
-        """
-        Profile is confirmed — ready for matching agent handoff.
-
-        TODO (contributor):
-          1. Emit handoff event via domain_client.log_event()
-          2. Trigger matching agent (when available)
-        """
-        msg = await llm_adapter.generate_response(
-            stage="matching_ready",
-            messages=request.conversation_history,
-            user_message=request.user_message,
-        )
-        return self._build_response(
-            message=msg,
-            next_state=EngagementWorkflowState.MATCHING_READY.value,
-            request=request,
-            completion_status="matching_ready",
-        )
-
-    async def _handle_paused(self, request: EngagementAgentTurnRequest) -> EngagementAgentTurnResponse:
-        """Volunteer paused the session."""
-        msg = await llm_adapter.generate_response(
-            stage="paused",
-            messages=request.conversation_history,
-            user_message=request.user_message,
-        )
-        return self._build_response(
-            message=msg,
+            message=_TERMINAL_MESSAGES[EngagementWorkflowState.PAUSED.value],
             next_state=EngagementWorkflowState.PAUSED.value,
-            request=request,
+            sub_state=sub_state,
+            completion_status="paused",
+            confirmed_fields=self._confirmed_fields(sub_state),
         )
 
-    async def _handle_fallback(self, request: EngagementAgentTurnRequest) -> EngagementAgentTurnResponse:
-        """Fallback for unknown stages."""
-        logger.warning(f"Unknown stage: {request.session_state.stage} — falling back to re_engaging")
-        return await self._handle_re_engaging(request)
+    async def _handle_fallback(
+        self,
+        request: EngagementAgentTurnRequest,
+        sub_state: Dict[str, Any],
+    ) -> EngagementAgentTurnResponse:
+        logger.warning("Unknown engagement stage '%s' — falling back to re_engaging", request.session_state.stage)
+        return await self._handle_re_engaging(request, sub_state)
 
-    # ── Helper ────────────────────────────────────────────────────────────────
+    async def _handle_decline(
+        self,
+        request: EngagementAgentTurnRequest,
+        sub_state: Dict[str, Any],
+    ) -> EngagementAgentTurnResponse:
+        sub_state["human_review_reason"] = "volunteer_declined"
+        await self._persist_signals(str(request.session_id), sub_state)
+        await domain_client.engagement_update_volunteer_status(
+            str(request.session_id),
+            volunteer_status="opt_out",
+            reason="volunteer_declined",
+            signals=self._confirmed_fields(sub_state),
+        )
+        await self._write_summary(
+            session_id=str(request.session_id),
+            volunteer_id=request.session_state.volunteer_id,
+            sub_state=sub_state,
+            outcome="declined",
+        )
+        return self._build_response(
+            message=(
+                "Thank you for letting us know. We won't push any further right now. "
+                "If you'd like to come back later, we'd be happy to reconnect."
+            ),
+            next_state=EngagementWorkflowState.HUMAN_REVIEW.value,
+            sub_state=sub_state,
+            completion_status="human_review",
+            confirmed_fields=self._confirmed_fields(sub_state),
+        )
+
+    async def _handle_defer(
+        self,
+        request: EngagementAgentTurnRequest,
+        sub_state: Dict[str, Any],
+    ) -> EngagementAgentTurnResponse:
+        await self._persist_signals(str(request.session_id), sub_state)
+        await domain_client.engagement_update_volunteer_status(
+            str(request.session_id),
+            volunteer_status="pause_outreach",
+            reason="volunteer_deferred",
+            signals=self._confirmed_fields(sub_state),
+        )
+        await self._write_summary(
+            session_id=str(request.session_id),
+            volunteer_id=request.session_state.volunteer_id,
+            sub_state=sub_state,
+            outcome="deferred",
+        )
+        return self._build_response(
+            message=(
+                "Absolutely. We can reconnect later when your timing is better. "
+                "Just message us whenever you're ready."
+            ),
+            next_state=EngagementWorkflowState.PAUSED.value,
+            sub_state=sub_state,
+            completion_status="paused",
+            confirmed_fields=self._confirmed_fields(sub_state),
+        )
+
+    async def _build_fulfillment_handoff_response(
+        self,
+        request: EngagementAgentTurnRequest,
+        sub_state: Dict[str, Any],
+    ) -> EngagementAgentTurnResponse:
+        await self._persist_signals(str(request.session_id), sub_state)
+        handoff_result = await domain_client.engagement_prepare_fulfillment_handoff(
+            str(request.session_id),
+            signals=self._confirmed_fields(sub_state),
+        )
+        updated_sub_state = handoff_result.get("sub_state") if isinstance(handoff_result, dict) else None
+        if isinstance(updated_sub_state, dict):
+            sub_state.update(updated_sub_state)
+        payload = (
+            handoff_result.get("handoff_payload")
+            or sub_state.get("handoff")
+            or self._build_fulfillment_payload(request, sub_state)
+        )
+        if not payload:
+            sub_state["human_review_reason"] = "missing_handoff_context"
+            await self._persist_signals(str(request.session_id), sub_state)
+            await domain_client.engagement_update_volunteer_status(
+                str(request.session_id),
+                volunteer_status="human_review",
+                reason="missing_handoff_context",
+                signals=self._confirmed_fields(sub_state),
+            )
+            await self._write_summary(
+                session_id=str(request.session_id),
+                volunteer_id=request.session_state.volunteer_id,
+                sub_state=sub_state,
+                outcome="human_review",
+            )
+            return self._build_response(
+                message=(
+                    "Thanks. I have your preference, but I need a teammate to check the details before moving ahead."
+                ),
+                next_state=EngagementWorkflowState.HUMAN_REVIEW.value,
+                sub_state=sub_state,
+                completion_status="human_review",
+                confirmed_fields=self._confirmed_fields(sub_state),
+            )
+
+        sub_state["handoff"] = payload
+        await self._persist_signals(str(request.session_id), sub_state)
+        await domain_client.engagement_update_volunteer_status(
+            str(request.session_id),
+            volunteer_status="opportunity_readiness",
+            reason="ready_for_fulfillment",
+            signals=self._confirmed_fields(sub_state),
+        )
+        await self._write_summary(
+            session_id=str(request.session_id),
+            volunteer_id=request.session_state.volunteer_id,
+            sub_state=sub_state,
+            outcome="handoff_to_fulfillment",
+        )
+
+        return self._build_response(
+            message=(
+                "Perfect. I’ve noted your preference and I’ll now check for the best teaching continuation for you."
+            ),
+            next_state="active",
+            sub_state=sub_state,
+            completion_status="handoff_ready",
+            confirmed_fields=self._confirmed_fields(sub_state),
+            handoff_event={
+                "session_id": request.session_id,
+                "from_agent": "engagement",
+                "to_agent": "fulfillment",
+                "handoff_type": "agent_transition",
+                "payload": payload,
+                "reason": "Volunteer confirmed continuation preferences",
+            },
+        )
+
+    async def _ensure_context_loaded(
+        self,
+        request: EngagementAgentTurnRequest,
+        sub_state: Dict[str, Any],
+    ) -> None:
+        if sub_state.get("engagement_context"):
+            return
+
+        volunteer_id = request.session_state.volunteer_id
+        if not volunteer_id:
+            return
+
+        context = await domain_client.get_engagement_context(str(volunteer_id))
+        if context.get("status") == "success":
+            sub_state["engagement_context"] = context
+        else:
+            logger.warning("Failed to load engagement context for volunteer %s: %s", volunteer_id, context)
+
+    def _extract_signals(self, message: str) -> Dict[str, Any]:
+        text = self._normalise(message)
+        if not text:
+            return {}
+
+        decision = None
+        if self._matches_any(text, _DEFER_PATTERNS):
+            decision = "defer"
+        elif self._matches_any(text, _DECLINE_PATTERNS):
+            decision = "decline"
+        elif self._matches_any(text, _CONTINUE_PATTERNS):
+            decision = "continue"
+
+        same_school = True if self._matches_any(text, _SAME_SCHOOL_PATTERNS) else None
+        if same_school is None and self._matches_any(text, _FLEX_SCHOOL_PATTERNS):
+            same_school = False
+
+        same_slot = True if self._matches_any(text, _SAME_SLOT_PATTERNS) else None
+        if same_slot is None and self._matches_any(text, _FLEX_SLOT_PATTERNS):
+            same_slot = False
+
+        open_to_alternatives = True if self._matches_any(text, _ALTERNATIVE_PATTERNS) else None
+        if open_to_alternatives:
+            if same_school is None:
+                same_school = False
+            if same_slot is None:
+                same_slot = False
+
+        if decision is None and any(v is not None for v in (same_school, same_slot, open_to_alternatives)):
+            decision = "continue"
+
+        return {
+            "continue_decision": decision,
+            "same_school": same_school,
+            "same_slot": same_slot,
+            "open_to_alternatives": open_to_alternatives,
+        }
+
+    def _merge_signals(self, sub_state: Dict[str, Any], signals: Dict[str, Any]) -> None:
+        for key in ("continue_decision", "same_school", "same_slot", "open_to_alternatives"):
+            value = signals.get(key)
+            if value is not None:
+                sub_state[key] = value
+
+        if sub_state.get("same_school") is True:
+            sub_state["continuity"] = "same"
+        elif sub_state.get("same_school") is False or sub_state.get("open_to_alternatives") is True:
+            sub_state["continuity"] = "different"
+
+        sub_state["preference_notes"] = self._build_preference_notes(sub_state)
+
+    def _build_preference_notes(self, sub_state: Dict[str, Any]) -> str:
+        context = sub_state.get("engagement_context") or {}
+        history = context.get("fulfillment_history") or []
+        latest = history[0] if history else {}
+
+        notes: List[str] = []
+        school_name = latest.get("school_name")
+        schedule = latest.get("schedule")
+        subjects = latest.get("subjects") or []
+        grades = latest.get("grade_levels") or []
+
+        if sub_state.get("same_school") is True and school_name:
+            notes.append(f"Prefer same school as before: {school_name}.")
+        elif sub_state.get("same_school") is False:
+            notes.append("Open to a different school if needed.")
+
+        if sub_state.get("same_slot") is True and schedule:
+            notes.append(f"Prefer same schedule as before: {schedule}.")
+        elif sub_state.get("same_slot") is False:
+            notes.append("Flexible on time slot.")
+
+        if sub_state.get("open_to_alternatives") is True:
+            notes.append("Open to alternatives if the previous match is unavailable.")
+
+        if subjects:
+            notes.append(f"Recent teaching subjects: {', '.join(subjects)}.")
+        if grades:
+            notes.append(f"Recent grade levels: {', '.join(str(g) for g in grades)}.")
+
+        return " ".join(notes).strip()
+
+    def _build_fulfillment_payload(
+        self,
+        request: EngagementAgentTurnRequest,
+        sub_state: Dict[str, Any],
+    ) -> Optional[Dict[str, Any]]:
+        volunteer_id = request.session_state.volunteer_id
+        if not volunteer_id:
+            return None
+
+        context = sub_state.get("engagement_context") or {}
+        history = context.get("fulfillment_history") or []
+        latest = history[0] if history else {}
+
+        payload = FulfillmentHandoffPayload(
+            volunteer_id=str(volunteer_id),
+            volunteer_name=self._resolve_volunteer_name(request, context),
+            continuity=sub_state.get("continuity") or "different",
+            preferred_need_id=latest.get("need_id") if sub_state.get("continuity") == "same" else None,
+            preferred_school_id=None,
+            preference_notes=sub_state.get("preference_notes") or None,
+            fulfillment_history=history,
+        )
+        return payload.model_dump(mode="json")
+
+    def _build_reengagement_prompt(
+        self,
+        request: EngagementAgentTurnRequest,
+        sub_state: Dict[str, Any],
+    ) -> str:
+        context = sub_state.get("engagement_context") or {}
+        history = context.get("fulfillment_history") or []
+        latest = history[0] if history else {}
+        name = self._resolve_volunteer_name(request, context)
+
+        if latest.get("school_name"):
+            return (
+                f"Welcome back, {name}! Last time you supported {latest['school_name']}. "
+                "Would you like to continue this year? We can try the same school and timing, or look at alternatives."
+            )
+        return (
+            f"Welcome back, {name}! Would you like to continue volunteering this year? "
+            "If yes, we can try the same school and timing as before or look at alternatives."
+        )
+
+    def _build_preference_question(self, sub_state: Dict[str, Any]) -> str:
+        missing = self._get_missing_preference_fields(sub_state)
+        if "school_preference" in missing and "slot_preference" in missing:
+            return (
+                "Would you prefer the same school and same time slot as before, "
+                "or are you open to different options?"
+            )
+        if "school_preference" in missing:
+            return "Would you like the same school as before, or are you open to a different school?"
+        return "Should we try for the same time slot as before, or are you flexible on timing?"
+
+    def _get_missing_preference_fields(self, sub_state: Dict[str, Any]) -> List[str]:
+        missing: List[str] = []
+        if sub_state.get("continue_decision") != "continue":
+            return missing
+        if sub_state.get("same_school") is None:
+            missing.append("school_preference")
+        if sub_state.get("same_slot") is None:
+            missing.append("slot_preference")
+        return missing
+
+    def _confirmed_fields(self, sub_state: Dict[str, Any]) -> Dict[str, Any]:
+        return {
+            "continue_decision": sub_state.get("continue_decision"),
+            "same_school": sub_state.get("same_school"),
+            "same_slot": sub_state.get("same_slot"),
+            "open_to_alternatives": sub_state.get("open_to_alternatives"),
+            "continuity": sub_state.get("continuity"),
+            "preference_notes": sub_state.get("preference_notes"),
+        }
+
+    async def _persist_signals(self, session_id: str, sub_state: Dict[str, Any]) -> None:
+        result = await domain_client.engagement_save_confirmed_signals(
+            session_id,
+            self._confirmed_fields(sub_state),
+        )
+        updated = result.get("sub_state") if isinstance(result, dict) else None
+        if isinstance(updated, dict):
+            sub_state.update(updated)
+
+    async def _write_summary(
+        self,
+        session_id: str,
+        volunteer_id: Optional[str],
+        sub_state: Dict[str, Any],
+        outcome: str,
+    ) -> None:
+        summary_text = self._build_summary_text(sub_state, outcome)
+        key_facts = [
+            f"Outcome: {outcome}",
+            f"Continue decision: {sub_state.get('continue_decision')}",
+            f"Continuity: {sub_state.get('continuity')}",
+            f"Same school: {sub_state.get('same_school')}",
+            f"Same slot: {sub_state.get('same_slot')}",
+        ]
+        await domain_client.save_memory_summary(
+            session_id=session_id,
+            summary_text=summary_text,
+            key_facts=[fact for fact in key_facts if not fact.endswith("None")],
+            volunteer_id=volunteer_id,
+        )
+
+    def _build_summary_text(self, sub_state: Dict[str, Any], outcome: str) -> str:
+        parts = [f"Engagement outcome: {outcome}."]
+        if sub_state.get("continue_decision"):
+            parts.append(f"Volunteer decision: {sub_state['continue_decision']}.")
+        if sub_state.get("continuity"):
+            parts.append(f"Continuity preference: {sub_state['continuity']}.")
+        if sub_state.get("preference_notes"):
+            parts.append(sub_state["preference_notes"])
+        if sub_state.get("human_review_reason"):
+            parts.append(f"Human review reason: {sub_state['human_review_reason']}.")
+        return " ".join(parts)
 
     def _build_response(
         self,
         message: str,
         next_state: str,
-        request: EngagementAgentTurnRequest,
+        sub_state: Dict[str, Any],
         completion_status: Optional[str] = None,
         confirmed_fields: Optional[Dict[str, Any]] = None,
+        handoff_event: Optional[Dict[str, Any]] = None,
     ) -> EngagementAgentTurnResponse:
         return EngagementAgentTurnResponse(
             assistant_message=message,
             state=next_state,
+            sub_state=_dump_sub_state(sub_state),
             completion_status=completion_status,
             confirmed_fields=confirmed_fields or {},
+            handoff_event=handoff_event,
         )
+
+    def _resolve_volunteer_name(
+        self,
+        request: EngagementAgentTurnRequest,
+        context: Dict[str, Any],
+    ) -> str:
+        if request.session_state.volunteer_name:
+            return request.session_state.volunteer_name
+        profile = context.get("volunteer_profile") or {}
+        return profile.get("full_name") or profile.get("first_name") or "Volunteer"
+
+    def _normalise(self, message: str) -> str:
+        return re.sub(r"\s+", " ", (message or "").strip().lower())
+
+    def _matches_any(self, text: str, patterns: List[str]) -> bool:
+        return any(re.search(pattern, text) for pattern in patterns)
 
 
 # Singleton

--- a/serve-fulfillment-agent-service/app/service/llm_adapter.py
+++ b/serve-fulfillment-agent-service/app/service/llm_adapter.py
@@ -119,7 +119,8 @@ WORKFLOW — follow this exactly:
 
 STEP 1 — FIND THE NEED (no user interaction):
 - Call get_engagement_context(volunteer_id) to load their history.
-- If continuity=same: call get_needs_for_entity(preferred_school_id).
+- If continuity=same and preferred_school_id is present: call get_needs_for_entity(preferred_school_id).
+- If continuity=same but preferred_school_id is missing: call resolve_school_context(school_hint=preference_notes).
 - If continuity=different: call resolve_school_context(school_hint=preference_notes).
 - For each candidate need, call get_need_details(need_id).
 - Call get_nominations_for_need(need_id, status="Approved") — skip needs with Approved nominations.

--- a/serve-mcp-server/main.py
+++ b/serve-mcp-server/main.py
@@ -32,6 +32,7 @@ from config import MCP_PORT, MCP_HOST
 from services.session_service     import SessionService
 from services.profile_service     import ProfileService
 from services.memory_service      import MemoryService
+from services.engagement_service  import engagement_service
 from services.coordinator_service import coordinator_service
 from services.school_service      import school_service
 from services.need_service        import need_service
@@ -46,6 +47,8 @@ from schemas import (
     GetMissingFieldsInput, SaveVolunteerFieldsInput, EvaluateReadinessInput,
     SaveMessageInput, GetConversationInput,
     SaveMemorySummaryInput, GetMemorySummaryInput,
+    EngagementSaveConfirmedSignalsInput,
+    EngagementUpdateVolunteerStatusInput, EngagementPrepareFulfillmentHandoffInput,
     LogEventInput, EmitHandoffEventInput,
     ResolveCoordinatorInput, CreateCoordinatorInput, MapCoordinatorToSchoolInput,
     ResolveSchoolContextInput, CreateSchoolContextInput, FetchPreviousNeedContextInput,
@@ -417,6 +420,45 @@ async def get_memory_summary(params: GetMemorySummaryInput) -> dict:
               or null if no summary exists
     """
     return await memory_service.get_summary(params.session_id)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ENGAGEMENT HYBRID TOOLS
+# ─────────────────────────────────────────────────────────────────────────────
+
+@mcp.tool()
+async def engagement_save_confirmed_signals(params: EngagementSaveConfirmedSignalsInput) -> dict:
+    """
+    Persist confirmed engagement signals into the session sub_state.
+    """
+    return await engagement_service.save_confirmed_signals(
+        session_id=params.session_id,
+        signals=params.signals,
+    )
+
+
+@mcp.tool()
+async def engagement_update_volunteer_status(params: EngagementUpdateVolunteerStatusInput) -> dict:
+    """
+    Persist the current engagement status and reason into the session state.
+    """
+    return await engagement_service.update_volunteer_status(
+        session_id=params.session_id,
+        volunteer_status=params.volunteer_status,
+        reason=params.reason,
+        signals=params.signals,
+    )
+
+
+@mcp.tool()
+async def engagement_prepare_fulfillment_handoff(params: EngagementPrepareFulfillmentHandoffInput) -> dict:
+    """
+    Build and persist the fulfillment handoff payload for the current engagement session.
+    """
+    return await engagement_service.prepare_fulfillment_handoff(
+        session_id=params.session_id,
+        signals=params.signals,
+    )
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -1213,58 +1255,53 @@ async def get_engagement_context(params: GetEngagementContextInput) -> dict:
         active_nominations:     list
         volunteer_profile:      profile dict from Serve Registry (may be null)
     """
-    from services.serve_registry_client import (
-        fulfillment_client, nomination_client, need_service_client, volunteering_client
+    return await engagement_service.get_engagement_context(params.volunteer_id)
+
+
+@mcp.tool()
+async def get_needs_for_entity(params: GetNeedsForEntityInput) -> dict:
+    """
+    Get open needs for a school/entity.
+
+    Used by: Fulfillment Agent
+
+    Args:
+        entity_id: Serve Need Service entity UUID
+        page: page number
+        size: page size
+
+    Returns:
+        needs: list of needs for the entity
+    """
+    from services.serve_registry_client import need_service_client
+
+    needs = await need_service_client.get_needs_for_entity(
+        params.entity_id,
+        page=params.page,
+        size=params.size,
     )
+    return {"status": "success", "needs": needs, "total": len(needs)}
 
-    COMPLETED_STATUSES = {"Completed", "Closed"}
-    ACTIVE_NOM_STATUSES = {"Nominated", "Approved", "Proposed"}
 
-    # Run all three fetches
-    raw_fulfillments, all_nominations, profile = await asyncio.gather(
-        fulfillment_client.get_fulfillments_for_volunteer(params.volunteer_id),
-        nomination_client.get_nominations_for_volunteer(params.volunteer_id),
-        volunteering_client.get_user_profile(params.volunteer_id),
-        return_exceptions=True,
-    )
+@mcp.tool()
+async def get_need_details(params: GetNeedDetailsInput) -> dict:
+    """
+    Get enriched details for a need.
 
-    # Fulfillment history — enrich completed ones
-    enriched = []
-    if isinstance(raw_fulfillments, list):
-        for f in raw_fulfillments:
-            if f.get("fulfillmentStatus") not in COMPLETED_STATUSES:
-                continue
-            need_id = f.get("needId", "")
-            need_detail = {}
-            if need_id:
-                try:
-                    need_detail = await need_service_client.get_need_details(need_id) or {}
-                except Exception:
-                    pass
-            enriched.append({
-                "fulfillment_id":    f.get("id"),
-                "need_id":           need_id,
-                "school_name":       need_detail.get("name", ""),
-                "subjects":          need_detail.get("subjects", []),
-                "grade_levels":      need_detail.get("grade_levels", []),
-                "schedule":          need_detail.get("days", ""),
-                "start_date":        need_detail.get("start_date", ""),
-                "end_date":          need_detail.get("end_date", ""),
-                "fulfillment_status": f.get("fulfillmentStatus"),
-            })
+    Used by: Fulfillment Agent
 
-    # Active nominations
-    active_noms = []
-    if isinstance(all_nominations, list):
-        active_noms = [n for n in all_nominations if n.get("nominationStatus") in ACTIVE_NOM_STATUSES]
+    Args:
+        need_id: Serve Need Service need UUID
 
-    return {
-        "status":               "success",
-        "fulfillment_history":  enriched,
-        "has_active_nomination": len(active_noms) > 0,
-        "active_nominations":   active_noms,
-        "volunteer_profile":    profile if isinstance(profile, dict) else None,
-    }
+    Returns:
+        need_details: flattened need detail object
+    """
+    from services.serve_registry_client import need_service_client
+
+    details = await need_service_client.get_need_details(params.need_id)
+    if not details:
+        return {"status": "error", "error": f"Need {params.need_id} not found"}
+    return {"status": "success", "need_details": details}
 
 
 @mcp.tool()

--- a/serve-mcp-server/schemas.py
+++ b/serve-mcp-server/schemas.py
@@ -277,6 +277,61 @@ class GetMemorySummaryInput(BaseModel):
         return v
 
 
+# ─── Engagement Hybrid Tools ─────────────────────────────────────────────────
+
+class EngagementSaveConfirmedSignalsInput(BaseModel):
+    session_id: str
+    signals: Dict[str, Any] = Field(default_factory=dict)
+
+    @field_validator("session_id")
+    @classmethod
+    def validate_uuid(cls, v: str) -> str:
+        import uuid
+        try:
+            uuid.UUID(v)
+        except ValueError:
+            raise ValueError(f"session_id must be a valid UUID, got: {v}")
+        return v
+
+
+class EngagementUpdateVolunteerStatusInput(BaseModel):
+    session_id: str
+    volunteer_status: Literal[
+        "continue_nurturing",
+        "opportunity_readiness",
+        "pause_outreach",
+        "opt_out",
+        "human_review",
+    ]
+    reason: Optional[str] = Field(default=None)
+    signals: Optional[Dict[str, Any]] = Field(default=None)
+
+    @field_validator("session_id")
+    @classmethod
+    def validate_uuid(cls, v: str) -> str:
+        import uuid
+        try:
+            uuid.UUID(v)
+        except ValueError:
+            raise ValueError(f"session_id must be a valid UUID, got: {v}")
+        return v
+
+
+class EngagementPrepareFulfillmentHandoffInput(BaseModel):
+    session_id: str
+    signals: Optional[Dict[str, Any]] = Field(default=None)
+
+    @field_validator("session_id")
+    @classmethod
+    def validate_uuid(cls, v: str) -> str:
+        import uuid
+        try:
+            uuid.UUID(v)
+        except ValueError:
+            raise ValueError(f"session_id must be a valid UUID, got: {v}")
+        return v
+
+
 # ─── Telemetry ────────────────────────────────────────────────────────────────
 
 class LogEventInput(BaseModel):
@@ -514,6 +569,16 @@ class GetEngagementContextInput(BaseModel):
         min_length=1,
         description="Serve Registry volunteer osid — returns fulfillment history + active nominations + profile in one call"
     )
+
+
+class GetNeedsForEntityInput(BaseModel):
+    entity_id: str = Field(min_length=1, description="Serve Need Service entity / school UUID")
+    page: int = Field(default=0, ge=0)
+    size: int = Field(default=20, ge=1, le=200)
+
+
+class GetNeedDetailsInput(BaseModel):
+    need_id: str = Field(min_length=1, description="Serve Need Service need UUID")
 
 
 class NominateVolunteerInput(BaseModel):

--- a/serve-mcp-server/services/engagement_service.py
+++ b/serve-mcp-server/services/engagement_service.py
@@ -1,0 +1,240 @@
+"""
+SERVE MCP Server - Engagement Service
+Hybrid engagement helpers used by the Engagement Agent.
+
+The agent still interprets free-form volunteer replies locally.
+This service owns stable persistence, context assembly,
+and handoff payload preparation.
+"""
+import asyncio
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from services.session_service import SessionService
+from services.serve_registry_client import (
+    fulfillment_client,
+    need_service_client,
+    nomination_client,
+    volunteering_client,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_ENGAGEMENT_SUB_STATE = {
+    "engagement_context": {},
+    "continue_decision": None,
+    "same_school": None,
+    "same_slot": None,
+    "open_to_alternatives": None,
+    "continuity": None,
+    "preference_notes": None,
+    "handoff": {},
+    "human_review_reason": None,
+    "volunteer_status": None,
+    "status_reason": None,
+}
+
+
+class EngagementService:
+    def __init__(self) -> None:
+        self._session_service = SessionService()
+
+    async def get_engagement_context(self, volunteer_id: Optional[str]) -> Dict[str, Any]:
+        """Fetch fulfillment history, active nominations, and volunteer profile."""
+        if not volunteer_id:
+            return {
+                "status": "error",
+                "error": "volunteer_id is required",
+            }
+
+        completed_statuses = {"Completed", "Closed"}
+        active_nom_statuses = {"Nominated", "Approved", "Proposed"}
+
+        raw_fulfillments, all_nominations, profile = await asyncio.gather(
+            fulfillment_client.get_fulfillments_for_volunteer(volunteer_id),
+            nomination_client.get_nominations_for_volunteer(volunteer_id),
+            volunteering_client.get_user_profile(volunteer_id),
+            return_exceptions=True,
+        )
+
+        enriched: List[Dict[str, Any]] = []
+        if isinstance(raw_fulfillments, list):
+            for f in raw_fulfillments:
+                if f.get("fulfillmentStatus") not in completed_statuses:
+                    continue
+                need_id = f.get("needId", "")
+                need_detail = {}
+                if need_id:
+                    try:
+                        need_detail = await need_service_client.get_need_details(need_id) or {}
+                    except Exception:
+                        pass
+                enriched.append({
+                    "fulfillment_id": f.get("id"),
+                    "need_id": need_id,
+                    "school_name": need_detail.get("name", ""),
+                    "subjects": need_detail.get("subjects", []),
+                    "grade_levels": need_detail.get("grade_levels", []),
+                    "schedule": need_detail.get("days", ""),
+                    "start_date": need_detail.get("start_date", ""),
+                    "end_date": need_detail.get("end_date", ""),
+                    "fulfillment_status": f.get("fulfillmentStatus"),
+                })
+
+        active_noms: List[Dict[str, Any]] = []
+        if isinstance(all_nominations, list):
+            active_noms = [n for n in all_nominations if n.get("nominationStatus") in active_nom_statuses]
+
+        return {
+            "status": "success",
+            "fulfillment_history": enriched,
+            "has_active_nomination": len(active_noms) > 0,
+            "active_nominations": active_noms,
+            "volunteer_profile": profile if isinstance(profile, dict) else None,
+        }
+
+    async def save_confirmed_signals(
+        self,
+        session_id: str,
+        signals: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Merge confirmed engagement signals into session sub_state and persist them."""
+        session_result = await self._session_service.get_session(session_id)
+        if session_result.get("status") != "success":
+            return session_result
+
+        session = session_result.get("session", {})
+        sub_state = self._load_sub_state(session.get("sub_state"))
+        for key, value in signals.items():
+            if value is not None:
+                sub_state[key] = value
+
+        await self._session_service.update_session_context(
+            session_id,
+            sub_state=json.dumps(sub_state),
+        )
+        return {
+            "status": "success",
+            "saved_signals": list(signals.keys()),
+            "sub_state": sub_state,
+        }
+
+    async def update_volunteer_status(
+        self,
+        session_id: str,
+        volunteer_status: str,
+        reason: Optional[str] = None,
+        signals: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Persist the current engagement status into session sub_state and telemetry."""
+        session_result = await self._session_service.get_session(session_id)
+        if session_result.get("status") != "success":
+            return session_result
+
+        session = session_result.get("session", {})
+        sub_state = self._load_sub_state(session.get("sub_state"))
+        sub_state["volunteer_status"] = volunteer_status
+        if reason:
+            sub_state["status_reason"] = reason
+        if signals:
+            for key, value in signals.items():
+                if value is not None:
+                    sub_state[key] = value
+
+        await self._session_service.update_session_context(
+            session_id,
+            sub_state=json.dumps(sub_state),
+        )
+        await self._session_service.log_event(
+            session_id=session_id,
+            event_type="engagement_status_updated",
+            agent="engagement",
+            domain="volunteer",
+            source_service="engagement_agent",
+            data={
+                "volunteer_status": volunteer_status,
+                "reason": reason,
+            },
+        )
+        return {
+            "status": "success",
+            "volunteer_status": volunteer_status,
+            "sub_state": sub_state,
+        }
+
+    async def prepare_fulfillment_handoff(
+        self,
+        session_id: str,
+        signals: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Build the fulfillment handoff payload from session state + engagement context."""
+        session_result = await self._session_service.get_session(session_id)
+        if session_result.get("status") != "success":
+            return session_result
+
+        session = session_result.get("session", {})
+        sub_state = self._load_sub_state(session.get("sub_state"))
+        if signals:
+            for key, value in signals.items():
+                if value is not None:
+                    sub_state[key] = value
+
+        volunteer_id = session.get("volunteer_id")
+        if not volunteer_id:
+            return {"status": "error", "error": "Session has no volunteer_id"}
+
+        engagement_context = sub_state.get("engagement_context") or {}
+        if not engagement_context:
+            engagement_context = await self.get_engagement_context(volunteer_id)
+            if engagement_context.get("status") == "success":
+                sub_state["engagement_context"] = engagement_context
+
+        history = engagement_context.get("fulfillment_history") or []
+        latest = history[0] if history else {}
+
+        continuity = sub_state.get("continuity") or "different"
+        volunteer_profile = engagement_context.get("volunteer_profile") or {}
+        volunteer_name = (
+            volunteer_profile.get("full_name")
+            or volunteer_profile.get("first_name")
+            or "Volunteer"
+        )
+
+        payload = {
+            "volunteer_id": str(volunteer_id),
+            "volunteer_name": volunteer_name,
+            "continuity": continuity,
+            "preferred_need_id": latest.get("need_id") if continuity == "same" else None,
+            "preferred_school_id": None,
+            "preference_notes": sub_state.get("preference_notes"),
+            "fulfillment_history": history,
+        }
+
+        sub_state["handoff"] = payload
+        await self._session_service.update_session_context(
+            session_id,
+            sub_state=json.dumps(sub_state),
+        )
+        return {
+            "status": "success",
+            "handoff_payload": payload,
+            "sub_state": sub_state,
+        }
+
+    def _load_sub_state(self, raw: Optional[str]) -> Dict[str, Any]:
+        if not raw:
+            return dict(_DEFAULT_ENGAGEMENT_SUB_STATE)
+        try:
+            data = json.loads(raw)
+            if not isinstance(data, dict):
+                return dict(_DEFAULT_ENGAGEMENT_SUB_STATE)
+            state = dict(_DEFAULT_ENGAGEMENT_SUB_STATE)
+            state.update(data)
+            return state
+        except (json.JSONDecodeError, ValueError):
+            logger.warning("Malformed engagement sub_state JSON in MCP session store")
+            return dict(_DEFAULT_ENGAGEMENT_SUB_STATE)
+
+
+engagement_service = EngagementService()

--- a/serve-mcp-server/services/session_service.py
+++ b/serve-mcp-server/services/session_service.py
@@ -245,6 +245,70 @@ class SessionService:
         return {"status": "error", "error_code": "SESSION_NOT_FOUND",
                 "error_message": f"Session {session_id} not found"}
 
+    async def update_session_context(
+        self,
+        session_id: str,
+        *,
+        sub_state: Optional[str] = None,
+        context_summary: Optional[str] = None,
+        status: Optional[str] = None,
+        active_agent: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Patch non-stage session fields without advancing the workflow state."""
+        values: Dict[str, Any] = {"updated_at": datetime.utcnow()}
+        if sub_state is not None:
+            values["sub_state"] = sub_state
+        if context_summary is not None:
+            values["context_summary"] = context_summary
+        if status is not None:
+            values["status"] = status
+        if active_agent is not None:
+            values["active_agent"] = active_agent
+
+        if len(values) == 1:
+            return {"status": "success", "updated_fields": []}
+
+        if is_db_healthy():
+            try:
+                async with get_db() as db:
+                    result = await db.execute(
+                        select(DBSession).where(DBSession.id == UUID(session_id))
+                    )
+                    row = result.scalar_one_or_none()
+                    if row:
+                        await db.execute(
+                            update(DBSession)
+                            .where(DBSession.id == UUID(session_id))
+                            .values(**values)
+                        )
+                        return {
+                            "status": "success",
+                            "updated_fields": [k for k in values if k != "updated_at"],
+                        }
+            except Exception as e:
+                logger.warning(f"DB update_session_context failed: {e}")
+
+        if session_id in _mem.sessions:
+            if sub_state is not None:
+                _mem.sessions[session_id]["sub_state"] = sub_state
+            if context_summary is not None:
+                _mem.sessions[session_id]["context_summary"] = context_summary
+            if status is not None:
+                _mem.sessions[session_id]["status"] = status
+            if active_agent is not None:
+                _mem.sessions[session_id]["active_agent"] = active_agent
+            _mem.sessions[session_id]["updated_at"] = datetime.utcnow().isoformat()
+            return {
+                "status": "success",
+                "updated_fields": [k for k in values if k != "updated_at"],
+            }
+
+        return {
+            "status": "error",
+            "error_code": "SESSION_NOT_FOUND",
+            "error_message": f"Session {session_id} not found",
+        }
+
     # ── Messages ──────────────────────────────────────────────────────────────
 
     async def save_message(

--- a/serve-mcp-server/tools/__init__.py
+++ b/serve-mcp-server/tools/__init__.py
@@ -37,6 +37,14 @@ TOOL_CATEGORIES: Dict[str, Dict] = {
         "description": "Long-term conversation memory summaries (persisted to DB)",
         "tools": ["save_memory_summary", "get_memory_summary"],
     },
+    "engagement": {
+        "description": "Hybrid engagement lifecycle helpers for continuity state and fulfillment handoff prep",
+        "tools": [
+            "engagement_save_confirmed_signals",
+            "engagement_update_volunteer_status",
+            "engagement_prepare_fulfillment_handoff",
+        ],
+    },
     "telemetry": {
         "description": "Telemetry, audit events and agent handoff logging",
         "tools": ["log_event", "emit_handoff_event"],
@@ -73,6 +81,16 @@ TOOL_CATEGORIES: Dict[str, Dict] = {
             "save_need_message",
             "log_need_event",
             "emit_need_handoff_event",
+        ],
+    },
+    "engagement_fulfillment": {
+        "description": "Volunteer re-engagement context and fulfillment matching helpers",
+        "tools": [
+            "get_engagement_context",
+            "get_needs_for_entity",
+            "get_need_details",
+            "nominate_volunteer_for_need",
+            "get_nominations_for_need",
         ],
     },
     "observability": {

--- a/serve-orchestrator/app/service/agent_router.py
+++ b/serve-orchestrator/app/service/agent_router.py
@@ -87,7 +87,7 @@ class AgentRegistry:
             'healthy': False,  # Conservative — undeployed; first probe may flip to True
             'last_check': None,
             'workflows': ['returning_volunteer', 'volunteer_engagement'],
-            'stages': ['re_engaging', 'profile_refresh', 'matching_ready', 'paused'],
+            'stages': ['re_engaging', 'profile_refresh', 'matching_ready', 'human_review', 'paused'],
         }
 
         # ── Helpline agent — cross-cutting support queries ───────────────────

--- a/serve-orchestrator/app/service/workflow_validator.py
+++ b/serve-orchestrator/app/service/workflow_validator.py
@@ -239,41 +239,65 @@ NEED_COORDINATION_WORKFLOW = WorkflowDefinition(
 RETURNING_VOLUNTEER_WORKFLOW = WorkflowDefinition(
     workflow_id='returning_volunteer',
     display_name='Returning Volunteer Re-engagement',
-    description='Re-engages returning volunteers, refreshes their profile, and prepares them for matching',
+    description='Re-engages returning volunteers, captures continuity preferences, and hands ready volunteers to fulfillment',
     initial_stage='re_engaging',
-    terminal_stages=['matching_ready'],
+    terminal_stages=['complete', 'human_review'],
     stages={
         're_engaging': WorkflowStageDefinition(
             stage_id='re_engaging',
             display_name='Welcome Back',
             responsible_agent='engagement',
-            valid_next_stages=['profile_refresh', 'paused'],
+            valid_next_stages=['profile_refresh', 'matching_ready', 'active', 'paused', 'human_review'],
             required_fields=[],
             can_pause=True,
         ),
         'profile_refresh': WorkflowStageDefinition(
             stage_id='profile_refresh',
-            display_name='Update Your Profile',
+            display_name='Confirm Continuation Preferences',
             responsible_agent='engagement',
-            valid_next_stages=['matching_ready', 'paused'],
-            required_fields=['availability'],
-            optional_fields=['skills', 'interests', 'preferred_causes'],
+            valid_next_stages=['matching_ready', 'active', 'paused', 'human_review'],
+            required_fields=[],
+            optional_fields=['same_school', 'same_slot', 'continuity'],
             can_pause=True,
         ),
         'matching_ready': WorkflowStageDefinition(
             stage_id='matching_ready',
-            display_name='Ready for Matching',
+            display_name='Ready For Fulfillment',
             responsible_agent='engagement',
-            valid_next_stages=[],  # Terminal — hand off to selection agent
-            required_fields=['availability'],
+            valid_next_stages=['active', 'paused', 'human_review'],
+            required_fields=[],
             can_pause=False,
             can_skip=False,
+        ),
+        'active': WorkflowStageDefinition(
+            stage_id='active',
+            display_name='Matching In Progress',
+            responsible_agent='fulfillment',
+            valid_next_stages=['complete', 'human_review', 'paused'],
+            required_fields=[],
+            can_pause=True,
+        ),
+        'complete': WorkflowStageDefinition(
+            stage_id='complete',
+            display_name='Matched',
+            responsible_agent='fulfillment',
+            valid_next_stages=[],
+            required_fields=[],
+            can_pause=False,
+        ),
+        'human_review': WorkflowStageDefinition(
+            stage_id='human_review',
+            display_name='Needs Human Follow-up',
+            responsible_agent='engagement',
+            valid_next_stages=[],
+            required_fields=[],
+            can_pause=False,
         ),
         'paused': WorkflowStageDefinition(
             stage_id='paused',
             display_name='Paused',
             responsible_agent='engagement',
-            valid_next_stages=['re_engaging', 'profile_refresh'],
+            valid_next_stages=['re_engaging', 'profile_refresh', 'active'],
             required_fields=[],
             can_pause=False,
         ),
@@ -459,13 +483,15 @@ class WorkflowValidator:
                 'fulfillment_handoff_ready'
             ],
             'returning_volunteer': [
-                're_engaging', 'profile_refresh', 'matching_ready'
+                're_engaging', 'profile_refresh', 'matching_ready', 'active', 'complete'
             ],
         }
         
         stage_order = stage_orders.get(workflow_id, [])
         
         if current_stage not in stage_order:
+            if workflow.is_terminal(current_stage):
+                return 100
             # Handle special states
             if current_stage in ['paused', 'human_review', 'refinement_required']:
                 return 50  # Midway indicator


### PR DESCRIPTION
**Summary**

This PR completes the MVP engagement flow for returning / not-utilized volunteers and simplifies the engagement agent’s MCP integration.

The engagement agent now:
- re-engages returning volunteers
- captures continue / defer / decline intent
- collects continuity preferences such as same school, same slot, or openness to alternatives
- routes ready volunteers to fulfillment with a structured handoff
- pauses or opts out respectfully when needed

**What Changed**

- Implemented the engagement state flow for `re_engaging`, `profile_refresh`, `matching_ready`, `paused`, and `human_review`
- Added lightweight local signal extraction for volunteer intent and continuity preferences
- Added fulfillment handoff preparation for continuation-ready volunteers
- Added engagement-specific MCP helpers that carry real domain behavior:
  - save confirmed signals
  - update volunteer status
  - prepare fulfillment handoff
  - load engagement context
- Reused generic MCP tools where possible for memory summaries, telemetry, and handoff logging
- Updated the returning-volunteer workflow so engagement can transition cleanly into fulfillment

**Why**

This keeps the MVP simple and practical:
- conversation handling stays in the engagement agent
- stable persistence and handoff preparation stay in MCP
- the engagement-to-fulfillment path is wired end to end