### PR TITLE
Feature/onboarding selection agent logic

### DIFF
--- a/serve-orchestrator/app/service/agent_router.py
+++ b/serve-orchestrator/app/service/agent_router.py
@@ -119,7 +119,7 @@ class AgentRegistry:
         self._agents['selection'] = {
             'url': os.environ.get('SELECTION_AGENT_URL', 'http://serve-selection-agent-service:8009'),
             'health_path': '/api/health',
-            'endpoint': '/api/evaluate',
+            'endpoint': '/api/turn',
             'timeout': 30.0,
             'healthy': False,  # Conservative — undeployed; first probe may flip to True
             'last_check': None,

--- a/serve-selection-agent-service/app/clients/domain_client.py
+++ b/serve-selection-agent-service/app/clients/domain_client.py
@@ -2,16 +2,13 @@
 SERVE Selection Agent Service - MCP Tool Client
 
 Calls serve-mcp-server tools via the MCP SSE protocol.
-Same transport pattern as the other agent services.
-
-TODO (contributor): Add methods as evaluation logic requires.
-  e.g. get_volunteer_profile, get_onboarding_summary, log_evaluation_result, etc.
+Selection reuses the generic profile, readiness, memory, and telemetry tools.
 """
 import asyncio
 import json
 import logging
 import os
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -21,7 +18,7 @@ _MCP_RETRIES = int(os.environ.get("MCP_RETRIES", "3"))
 
 async def _call_mcp_tool(tool_name: str, arguments: Dict[str, Any]) -> Dict:
     """Call an MCP server tool via SSE transport with retry."""
-    last_error = None
+    last_error: Exception | None = None
     wire_args = {"params": arguments} if arguments else {}
 
     for attempt in range(_MCP_RETRIES):
@@ -46,5 +43,35 @@ async def _call_mcp_tool(tool_name: str, arguments: Dict[str, Any]) -> Dict:
             if attempt < _MCP_RETRIES - 1:
                 await asyncio.sleep(0.5 * (2 ** attempt))
 
-    logger.error(f"MCP tool [{tool_name}] failed after {_MCP_RETRIES} attempts: {last_error}")
+    logger.error("MCP tool [%s] failed after %s attempts: %s", tool_name, _MCP_RETRIES, last_error)
     return {"status": "error", "error": str(last_error)}
+
+
+class DomainClient:
+    async def get_volunteer_profile(self, session_id: str) -> Dict[str, Any]:
+        return await _call_mcp_tool("get_volunteer_profile", {"session_id": session_id})
+
+    async def evaluate_readiness(self, session_id: str) -> Dict[str, Any]:
+        return await _call_mcp_tool("evaluate_readiness", {"session_id": session_id})
+
+    async def get_memory_summary(self, session_id: str) -> Dict[str, Any]:
+        return await _call_mcp_tool("get_memory_summary", {"session_id": session_id})
+
+    async def log_event(
+        self,
+        session_id: str,
+        event_type: str,
+        data: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        return await _call_mcp_tool(
+            "log_event",
+            {
+                "session_id": session_id,
+                "event_type": event_type,
+                "agent": "selection",
+                "data": data or {},
+            },
+        )
+
+
+domain_client = DomainClient()

--- a/serve-selection-agent-service/app/schemas/selection_schemas.py
+++ b/serve-selection-agent-service/app/schemas/selection_schemas.py
@@ -1,14 +1,34 @@
 """
 SERVE Selection Agent Service - Schemas
 
-Silent evaluation agent. No volunteer-facing conversation.
-Receives a volunteer profile after onboarding, evaluates readiness,
-and returns a recommendation: recommend | not_recommend | hold.
+Selection is a lightweight post-onboarding evaluation agent.
+It accepts the standard orchestrator turn contract, evaluates the
+completed volunteer profile, and returns a concise next-step message.
 """
+import json
+from enum import Enum
 from typing import Any, Dict, List, Optional
 from uuid import UUID
-from enum import Enum
+
 from pydantic import BaseModel, Field
+
+
+class AgentType(str, Enum):
+    ONBOARDING = "onboarding"
+    SELECTION = "selection"
+    ENGAGEMENT = "engagement"
+    NEED = "need"
+    FULFILLMENT = "fulfillment"
+    DELIVERY_ASSISTANT = "delivery_assistant"
+
+
+class WorkflowType(str, Enum):
+    NEW_VOLUNTEER_ONBOARDING = "new_volunteer_onboarding"
+    RETURNING_VOLUNTEER = "returning_volunteer"
+    RECOMMENDED_VOLUNTEER = "recommended_volunteer"
+    NEED_COORDINATION = "need_coordination"
+    VOLUNTEER_ENGAGEMENT = "volunteer_engagement"
+    SYSTEM_TRIGGERED = "system_triggered"
 
 
 class SelectionOutcome(str, Enum):
@@ -17,10 +37,64 @@ class SelectionOutcome(str, Enum):
     HOLD = "hold"
 
 
+class EventType(str, Enum):
+    MCP_CALL = "mcp_call"
+    AGENT_RESPONSE = "agent_response"
+    HANDOFF = "handoff"
+    ERROR = "error"
+
+
+class SessionState(BaseModel):
+    id: UUID
+    channel: str
+    persona: str
+    workflow: str
+    active_agent: str
+    status: str
+    stage: str
+    sub_state: Optional[str] = None
+    context_summary: Optional[str] = None
+    channel_metadata: Optional[Dict[str, Any]] = None
+    volunteer_id: Optional[UUID] = None
+    volunteer_name: Optional[str] = None
+    volunteer_phone: Optional[str] = None
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class AgentTurnRequest(BaseModel):
+    session_id: UUID
+    session_state: SessionState
+    user_message: str
+    conversation_history: List[Dict[str, str]] = Field(default_factory=list)
+    intent_hint: Optional[str] = None
+    channel_metadata: Optional[Dict[str, Any]] = None
+
+
+class TelemetryEvent(BaseModel):
+    session_id: UUID
+    event_type: EventType
+    agent: Optional[AgentType] = None
+    data: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AgentTurnResponse(BaseModel):
+    assistant_message: str
+    active_agent: AgentType
+    workflow: WorkflowType
+    state: str
+    sub_state: Optional[str] = None
+    completion_status: Optional[str] = None
+    confirmed_fields: Dict[str, Any] = Field(default_factory=dict)
+    missing_fields: List[str] = Field(default_factory=list)
+    handoff_event: Optional[Dict[str, Any]] = None
+    telemetry_events: List[TelemetryEvent] = Field(default_factory=list)
+
+
 class VolunteerProfile(BaseModel):
-    """Profile data received from onboarding handoff."""
     volunteer_id: Optional[str] = None
     full_name: Optional[str] = None
+    first_name: Optional[str] = None
     email: Optional[str] = None
     phone: Optional[str] = None
     location: Optional[str] = None
@@ -28,11 +102,13 @@ class VolunteerProfile(BaseModel):
     interests: List[str] = Field(default_factory=list)
     availability: Optional[str] = None
     languages: List[str] = Field(default_factory=list)
-    experience: Optional[str] = None
+    motivation: Optional[str] = None
+    qualification: Optional[str] = None
+    years_of_experience: Optional[str] = None
+    employment_status: Optional[str] = None
 
 
 class SelectionEvaluateRequest(BaseModel):
-    """Request to evaluate a volunteer after onboarding."""
     session_id: UUID
     volunteer_id: Optional[str] = None
     profile: VolunteerProfile
@@ -42,7 +118,6 @@ class SelectionEvaluateRequest(BaseModel):
 
 
 class SelectionEvaluateResponse(BaseModel):
-    """Evaluation result — no volunteer-facing message."""
     session_id: UUID
     volunteer_id: Optional[str] = None
     outcome: SelectionOutcome
@@ -51,3 +126,17 @@ class SelectionEvaluateResponse(BaseModel):
     flags: List[str] = Field(default_factory=list)
     recommended_actions: List[str] = Field(default_factory=list)
     evaluation_details: Dict[str, Any] = Field(default_factory=dict)
+
+
+def extract_handoff_payload(raw_sub_state: Optional[str]) -> Dict[str, Any]:
+    """Extract the orchestrator-persisted handoff payload from session sub_state."""
+    if not raw_sub_state:
+        return {}
+    try:
+        data = json.loads(raw_sub_state)
+    except (json.JSONDecodeError, ValueError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    handoff = data.get("handoff")
+    return handoff if isinstance(handoff, dict) else {}

--- a/serve-selection-agent-service/app/service/selection_logic.py
+++ b/serve-selection-agent-service/app/service/selection_logic.py
@@ -1,87 +1,246 @@
 """
 SERVE Selection Agent Service - Core Evaluation Logic
 
-Silent agent — no volunteer-facing conversation.
-Called after onboarding completes. Evaluates the volunteer profile
-and returns: recommend | not_recommend | hold.
-
-TODO (contributor): Implement actual evaluation criteria.
-  - Profile completeness checks
-  - Skill/availability validation
-  - LLM-based motivation assessment (optional, via llm_adapter)
-  - Flag generation for ops review
+Selection is a lightweight post-onboarding evaluator.
+It reads the onboarding handoff + MCP profile state, classifies the profile,
+logs the outcome, and returns a concise next-step response.
 """
 import logging
 from typing import Any, Dict, List
 
+from app.clients.domain_client import domain_client
 from app.schemas.selection_schemas import (
+    AgentTurnRequest,
+    AgentTurnResponse,
+    AgentType,
+    EventType,
     SelectionEvaluateRequest,
     SelectionEvaluateResponse,
     SelectionOutcome,
+    TelemetryEvent,
+    VolunteerProfile,
+    WorkflowType,
+    extract_handoff_payload,
 )
 
 logger = logging.getLogger(__name__)
 
 
 class SelectionAgentService:
-    """
-    Stateless evaluation service.
-    Receives a profile, returns a recommendation. No conversation state.
-    """
+    """Evaluate completed onboarding profiles and recommend the next internal action."""
+
+    async def process_turn(self, request: AgentTurnRequest) -> AgentTurnResponse:
+        evaluation_request = await self._build_evaluation_request(request)
+        evaluation = await self.evaluate(evaluation_request)
+
+        await domain_client.log_event(
+            str(request.session_id),
+            "selection_evaluated",
+            {
+                "outcome": evaluation.outcome.value,
+                "confidence": evaluation.confidence,
+                "reason": evaluation.reason,
+                "flags": evaluation.flags,
+                "recommended_actions": evaluation.recommended_actions,
+            },
+        )
+
+        telemetry_events = [
+            TelemetryEvent(
+                session_id=request.session_id,
+                event_type=EventType.AGENT_RESPONSE,
+                agent=AgentType.SELECTION,
+                data={
+                    "outcome": evaluation.outcome.value,
+                    "confidence": evaluation.confidence,
+                },
+            )
+        ]
+
+        return AgentTurnResponse(
+            assistant_message=self._build_assistant_message(request, evaluation),
+            active_agent=AgentType.SELECTION,
+            workflow=WorkflowType(request.session_state.workflow),
+            state=request.session_state.stage,
+            completion_status=self._completion_status(evaluation.outcome),
+            confirmed_fields={
+                "selection_outcome": evaluation.outcome.value,
+                "selection_confidence": evaluation.confidence,
+                "selection_reason": evaluation.reason,
+            },
+            missing_fields=evaluation.evaluation_details.get("missing_fields", []),
+            telemetry_events=telemetry_events,
+        )
 
     async def evaluate(self, request: SelectionEvaluateRequest) -> SelectionEvaluateResponse:
-        """
-        Evaluate a volunteer after onboarding.
+        """Rule-based profile evaluation using MCP readiness + onboarding context."""
+        profile = request.profile
+        metadata = request.metadata or {}
+        missing_fields = list(metadata.get("missing_fields", []))
+        readiness_recommendation = metadata.get("readiness_recommendation")
+        readiness_reason = metadata.get("readiness_reason")
+        ready_for_selection = bool(metadata.get("ready_for_selection"))
 
-        TODO (contributor): Replace stub with real evaluation logic.
-        """
-        session_id = str(request.session_id)
-        logger.info(f"Selection evaluation for session {session_id}")
-
-        # ── Stub: always recommend ────────────────────────────────────────────
-        # Replace this with actual evaluation criteria.
-        outcome = SelectionOutcome.RECOMMEND
-        confidence = 0.5
-        reason = "Stub evaluation — no criteria applied yet"
         flags: List[str] = []
         recommended_actions: List[str] = []
 
-        # Example skeleton for contributor:
-        # ──────────────────────────────────────────────────────────────────────
-        # profile = request.profile
-        #
-        # # Check completeness
-        # if not profile.skills:
-        #     flags.append("no_skills_listed")
-        # if not profile.availability:
-        #     flags.append("no_availability")
-        #
-        # # Rule-based scoring
-        # score = self._compute_score(profile)
-        #
-        # # Optional: LLM evaluation
-        # from app.service.llm_adapter import llm_adapter
-        # llm_result = await llm_adapter.evaluate_profile(profile.model_dump())
-        #
-        # # Decision
-        # if score >= 0.7:
-        #     outcome = SelectionOutcome.RECOMMEND
-        # elif score >= 0.4:
-        #     outcome = SelectionOutcome.HOLD
-        # else:
-        #     outcome = SelectionOutcome.NOT_RECOMMEND
-        # ──────────────────────────────────────────────────────────────────────
+        if metadata.get("profile_load_error"):
+            flags.append("profile_load_error")
+        if metadata.get("memory_load_error"):
+            flags.append("memory_load_error")
+        if not (profile.email or profile.phone):
+            flags.append("missing_primary_contact")
+        if not profile.skills:
+            flags.append("missing_skills")
+        if not profile.availability:
+            flags.append("missing_availability")
+        if not profile.full_name:
+            flags.append("missing_name")
+
+        profile_strength = 0
+        if profile.full_name:
+            profile_strength += 1
+        if profile.email or profile.phone:
+            profile_strength += 1
+        if profile.skills:
+            profile_strength += 1
+        if profile.availability:
+            profile_strength += 1
+        if profile.interests:
+            profile_strength += 1
+        if profile.languages:
+            profile_strength += 1
+
+        if ready_for_selection:
+            outcome = SelectionOutcome.RECOMMEND
+            confidence = min(0.7 + (profile_strength * 0.04), 0.95)
+            reason = readiness_reason or "Volunteer profile is complete and ready for the next step."
+            recommended_actions = ["queue_for_matching_review", "notify_ops_ready"]
+        elif metadata.get("profile_load_error") or len(missing_fields) >= 3:
+            outcome = SelectionOutcome.NOT_RECOMMEND
+            confidence = 0.8
+            reason = readiness_reason or "Profile is too incomplete to recommend automatically."
+            recommended_actions = ["manual_review_profile", "request_profile_completion"]
+        else:
+            outcome = SelectionOutcome.HOLD
+            confidence = 0.65
+            reason = readiness_reason or "Profile needs a small amount of follow-up before recommending."
+            recommended_actions = ["collect_missing_profile_fields", "re-run_selection"]
+
+        evaluation_details = {
+            "missing_fields": missing_fields,
+            "readiness_recommendation": readiness_recommendation,
+            "profile_strength": profile_strength,
+            "onboarding_summary_available": bool(request.onboarding_summary),
+            "key_facts_count": len(request.key_facts),
+        }
 
         return SelectionEvaluateResponse(
             session_id=request.session_id,
             volunteer_id=request.volunteer_id,
             outcome=outcome,
-            confidence=confidence,
+            confidence=round(confidence, 2),
             reason=reason,
             flags=flags,
             recommended_actions=recommended_actions,
+            evaluation_details=evaluation_details,
         )
 
+    async def _build_evaluation_request(self, request: AgentTurnRequest) -> SelectionEvaluateRequest:
+        session_id = str(request.session_id)
+        handoff = extract_handoff_payload(request.session_state.sub_state)
 
-# Singleton
+        profile_result = await domain_client.get_volunteer_profile(session_id)
+        readiness_result = await domain_client.evaluate_readiness(session_id)
+        memory_result = await domain_client.get_memory_summary(session_id)
+
+        profile_data = profile_result.get("profile", {}) if isinstance(profile_result, dict) else {}
+        confirmed_fields = handoff.get("confirmed_fields", {})
+        merged_profile = self._merge_profile(profile_data, confirmed_fields)
+
+        memory_data = memory_result.get("data") if isinstance(memory_result, dict) else None
+        onboarding_summary = handoff.get("memory_summary") or (memory_data or {}).get("summary_text")
+        key_facts = handoff.get("key_facts") or (memory_data or {}).get("key_facts", [])
+
+        metadata = {
+            "ready_for_selection": readiness_result.get("ready_for_selection", False),
+            "missing_fields": readiness_result.get("missing_fields", []),
+            "readiness_recommendation": readiness_result.get("recommendation"),
+            "readiness_reason": readiness_result.get("reason"),
+            "profile_load_error": profile_result.get("status") == "error",
+            "memory_load_error": memory_result.get("status") == "error",
+            "handoff_present": bool(handoff),
+        }
+
+        volunteer_id = (
+            str(request.session_state.volunteer_id)
+            if request.session_state.volunteer_id
+            else handoff.get("volunteer_id")
+            or profile_data.get("volunteer_id")
+        )
+
+        return SelectionEvaluateRequest(
+            session_id=request.session_id,
+            volunteer_id=volunteer_id,
+            profile=VolunteerProfile(**merged_profile),
+            onboarding_summary=onboarding_summary,
+            key_facts=key_facts,
+            metadata=metadata,
+        )
+
+    def _merge_profile(self, profile_data: Dict[str, Any], confirmed_fields: Dict[str, Any]) -> Dict[str, Any]:
+        merged = dict(profile_data or {})
+        for key, value in (confirmed_fields or {}).items():
+            if value is not None:
+                merged[key] = value
+        return {
+            "volunteer_id": merged.get("volunteer_id"),
+            "full_name": merged.get("full_name"),
+            "first_name": merged.get("first_name"),
+            "email": merged.get("email"),
+            "phone": merged.get("phone"),
+            "location": merged.get("location"),
+            "skills": merged.get("skills") or [],
+            "interests": merged.get("interests") or [],
+            "availability": merged.get("availability"),
+            "languages": merged.get("languages") or [],
+            "motivation": merged.get("motivation"),
+            "qualification": merged.get("qualification"),
+            "years_of_experience": str(merged.get("years_of_experience")) if merged.get("years_of_experience") is not None else None,
+            "employment_status": merged.get("employment_status"),
+        }
+
+    def _build_assistant_message(
+        self,
+        request: AgentTurnRequest,
+        evaluation: SelectionEvaluateResponse,
+    ) -> str:
+        if request.user_message == "__handoff__":
+            if evaluation.outcome == SelectionOutcome.RECOMMEND:
+                return (
+                    "Thanks, your profile looks complete. We're reviewing it for the next step and "
+                    "will move you forward shortly."
+                )
+            if evaluation.outcome == SelectionOutcome.HOLD:
+                return (
+                    "Thanks, your profile is with us. We may need one small follow-up before moving you ahead."
+                )
+            return (
+                "Thanks for completing your profile. Our team will review it and follow up on the best next step."
+            )
+
+        if evaluation.outcome == SelectionOutcome.RECOMMEND:
+            return "Your profile looks strong for the next step. We’re moving it forward for matching review."
+        if evaluation.outcome == SelectionOutcome.HOLD:
+            return "Your profile is under review. We may come back with a small follow-up if needed."
+        return "Your profile needs a manual review before we can move it ahead."
+
+    def _completion_status(self, outcome: SelectionOutcome) -> str:
+        if outcome == SelectionOutcome.RECOMMEND:
+            return "recommended"
+        if outcome == SelectionOutcome.HOLD:
+            return "hold"
+        return "not_recommended"
+
+
 selection_agent_service = SelectionAgentService()

--- a/serve-selection-agent-service/main.py
+++ b/serve-selection-agent-service/main.py
@@ -1,20 +1,20 @@
 """
 SERVE Selection Agent Service
 
-Silent evaluation agent — no volunteer-facing conversation.
-Receives volunteer profile after onboarding, evaluates, returns recommendation.
-
-Endpoints:
-  POST /api/evaluate  — run evaluation
-  GET  /api/health    — health check
+Post-onboarding evaluation agent.
+Supports the standard orchestrator turn contract and keeps `/api/evaluate`
+for direct internal evaluation/debugging.
 """
 import logging
 import os
-from fastapi import FastAPI
-from fastapi.middleware.cors import CORSMiddleware
 from datetime import datetime
 
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
 from app.schemas.selection_schemas import (
+    AgentTurnRequest,
+    AgentTurnResponse,
     SelectionEvaluateRequest,
     SelectionEvaluateResponse,
 )
@@ -23,7 +23,7 @@ from app.service.selection_logic import selection_agent_service
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-app = FastAPI(title="SERVE Selection Agent", version="0.1.0")
+app = FastAPI(title="SERVE Selection Agent", version="0.2.0")
 
 app.add_middleware(
     CORSMiddleware,
@@ -33,10 +33,17 @@ app.add_middleware(
 )
 
 
+@app.post("/api/turn", response_model=AgentTurnResponse)
+async def process_turn(request: AgentTurnRequest):
+    """Process the orchestrator handoff / follow-up turn for selection."""
+    logger.info("Selection turn request for session %s", request.session_id)
+    return await selection_agent_service.process_turn(request)
+
+
 @app.post("/api/evaluate", response_model=SelectionEvaluateResponse)
 async def evaluate(request: SelectionEvaluateRequest):
-    """Evaluate a volunteer profile and return recommendation."""
-    logger.info(f"Evaluation request for session {request.session_id}")
+    """Run the underlying profile evaluation directly."""
+    logger.info("Direct selection evaluation request for session %s", request.session_id)
     return await selection_agent_service.evaluate(request)
 
 
@@ -51,6 +58,7 @@ async def health():
 
 if __name__ == "__main__":
     import uvicorn
+
     uvicorn.run(
         "main:app",
         host="0.0.0.0",


### PR DESCRIPTION
Implemented the selection agent end to end. This change updates `serve-selection-agent-service` to support the standard `/api/turn` agent contract, consume onboarding handoff context, and run a basic rule-based selection evaluation with outcomes such as `recommend`, `hold`, and `not_recommend`. It also retains `/api/evaluate` for direct internal evaluation and updates the orchestrator router to invoke the selection agent via `/api/turn`, making the onboarding-to-selection handoff functional.