### PR TITLE
fix: detect non-Anthropic provider keys so OpenRouter/OpenAI/Gemini work

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,8 +57,11 @@ services:
       - CORS_ORIGINS=*
       - MCP_SERVER_URL=http://serve-mcp-server:8004
       - LLM_PROVIDER=claude
-      - LLM_MODEL=claude-haiku-4-5-20251001
+      - LLM_MODEL=${LLM_MODEL:-claude-haiku-4-5-20251001}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - ONBOARDING_WELCOME_VIDEO_URL=${ONBOARDING_WELCOME_VIDEO_URL:-}
       - ONBOARDING_CLASSROOM_VIDEO_URL=${ONBOARDING_CLASSROOM_VIDEO_URL:-}
       - ONBOARDING_MEDIA_BASE_URL=${ONBOARDING_MEDIA_BASE_URL:-http://localhost:8002/media}
@@ -85,8 +88,11 @@ services:
       - CORS_ORIGINS=*
       - MCP_SERVER_URL=http://serve-mcp-server:8004
       - LLM_PROVIDER=claude
-      - LLM_MODEL=claude-sonnet-4-5-20250929
+      - LLM_MODEL=${LLM_MODEL:-claude-sonnet-4-5-20250929}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - NEED_START_DATE=${NEED_START_DATE:-2026-04-06}
       - APPLICABLE_GRADES=${APPLICABLE_GRADES:-6,7,8}
     ports:
@@ -121,6 +127,9 @@ services:
       - SELECTION_AGENT_URL=http://serve-selection-agent-service:8009
       - ENGAGEMENT_AGENT_URL=http://serve-engagement-agent-service:8006
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - PERSONA_LLM_MODEL=${PERSONA_LLM_MODEL:-claude-haiku-4-5-20251001}
     ports:
       - "8001:8001"
@@ -147,8 +156,11 @@ services:
       - CORS_ORIGINS=*
       - MCP_SERVER_URL=http://serve-mcp-server:8004
       - LLM_PROVIDER=claude
-      - LLM_MODEL=claude-sonnet-4-5-20250929
+      - LLM_MODEL=${LLM_MODEL:-claude-sonnet-4-5-20250929}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - ENGAGEMENT_MAX_START_DELAY_DAYS=${ENGAGEMENT_MAX_START_DELAY_DAYS:-10}
     ports:
       - "8006:8006"
@@ -173,8 +185,11 @@ services:
       - CORS_ORIGINS=*
       - MCP_SERVER_URL=http://serve-mcp-server:8004
       - LLM_PROVIDER=claude
-      - LLM_MODEL=claude-sonnet-4-5-20250929
+      - LLM_MODEL=${LLM_MODEL:-claude-sonnet-4-5-20250929}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
     ports:
       - "8007:8007"
     depends_on:
@@ -197,8 +212,11 @@ services:
       - PORT=8009
       - CORS_ORIGINS=*
       - MCP_SERVER_URL=http://serve-mcp-server:8004
-      - LLM_MODEL=claude-sonnet-4-5-20250929
+      - LLM_MODEL=${LLM_MODEL:-claude-sonnet-4-5-20250929}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - OPENAI_API_KEY=${OPENAI_API_KEY:-}
+      - GEMINI_API_KEY=${GEMINI_API_KEY:-}
       - TEACHING_LANGUAGE=${TEACHING_LANGUAGE:-English}
     ports:
       - "8009:8009"

--- a/serve-engagement-agent-service/app/service/llm_adapter.py
+++ b/serve-engagement-agent-service/app/service/llm_adapter.py
@@ -190,12 +190,17 @@ class EngagementLLMAdapter:
     """L3.5 tool-calling loop for the engagement agent. Model-agnostic via LiteLLM."""
 
     def __init__(self) -> None:
-        self._api_key: Optional[str] = (
-            os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("EMERGENT_LLM_KEY")
+        self._api_key: Optional[str] = next(
+            (os.environ[k] for k in (
+                "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY",
+                "OPENAI_API_KEY", "GEMINI_API_KEY", "EMERGENT_LLM_KEY",
+            ) if os.environ.get(k)),
+            None,
         )
         self._model: str = os.environ.get("LLM_MODEL", "claude-sonnet-4-5-20250929")
-        if self._api_key and not os.environ.get("ANTHROPIC_API_KEY"):
-            os.environ["ANTHROPIC_API_KEY"] = self._api_key
+        # Emergent key is Anthropic-compatible; map it so LiteLLM finds it.
+        if os.environ.get("EMERGENT_LLM_KEY") and not os.environ.get("ANTHROPIC_API_KEY"):
+            os.environ["ANTHROPIC_API_KEY"] = os.environ["EMERGENT_LLM_KEY"]
 
     def build_system_prompt(self, session_context: Dict[str, Any]) -> str:
         """Build system prompt with injected volunteer session context."""

--- a/serve-engagement-agent-service/app/service/recommended_llm_adapter.py
+++ b/serve-engagement-agent-service/app/service/recommended_llm_adapter.py
@@ -178,12 +178,17 @@ class RecommendedLLMAdapter:
     """Tool-calling loop for the recommended volunteer workflow. Model-agnostic via LiteLLM."""
 
     def __init__(self) -> None:
-        self._api_key: Optional[str] = (
-            os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("EMERGENT_LLM_KEY")
+        self._api_key: Optional[str] = next(
+            (os.environ[k] for k in (
+                "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY",
+                "OPENAI_API_KEY", "GEMINI_API_KEY", "EMERGENT_LLM_KEY",
+            ) if os.environ.get(k)),
+            None,
         )
         self._model: str = os.environ.get("LLM_MODEL", "claude-sonnet-4-5-20250929")
-        if self._api_key and not os.environ.get("ANTHROPIC_API_KEY"):
-            os.environ["ANTHROPIC_API_KEY"] = self._api_key
+        # Emergent key is Anthropic-compatible; map it so LiteLLM finds it.
+        if os.environ.get("EMERGENT_LLM_KEY") and not os.environ.get("ANTHROPIC_API_KEY"):
+            os.environ["ANTHROPIC_API_KEY"] = os.environ["EMERGENT_LLM_KEY"]
 
     def build_system_prompt(self, session_context: Dict[str, Any]) -> str:
         """Build system prompt with injected session context and registration URL."""

--- a/serve-fulfillment-agent-service/app/service/llm_adapter.py
+++ b/serve-fulfillment-agent-service/app/service/llm_adapter.py
@@ -126,13 +126,17 @@ class FulfillmentLLMAdapter:
     """Minimal LLM adapter — present match, confirm, nominate. Model-agnostic via LiteLLM."""
 
     def __init__(self) -> None:
-        self._api_key: Optional[str] = (
-            os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("EMERGENT_LLM_KEY")
+        self._api_key: Optional[str] = next(
+            (os.environ[k] for k in (
+                "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY",
+                "OPENAI_API_KEY", "GEMINI_API_KEY", "EMERGENT_LLM_KEY",
+            ) if os.environ.get(k)),
+            None,
         )
         self._model: str = os.environ.get("LLM_MODEL", "claude-sonnet-4-5-20250929")
-        # Set API key for LiteLLM
-        if self._api_key and not os.environ.get("ANTHROPIC_API_KEY"):
-            os.environ["ANTHROPIC_API_KEY"] = self._api_key
+        # Emergent key is Anthropic-compatible; map it so LiteLLM finds it.
+        if os.environ.get("EMERGENT_LLM_KEY") and not os.environ.get("ANTHROPIC_API_KEY"):
+            os.environ["ANTHROPIC_API_KEY"] = os.environ["EMERGENT_LLM_KEY"]
 
     def build_support_prompt(self, handoff: Dict[str, Any]) -> str:
         """System prompt for human_review stage — support mode, no nomination."""

--- a/serve-need-agent-service/app/service/llm_adapter.py
+++ b/serve-need-agent-service/app/service/llm_adapter.py
@@ -298,10 +298,17 @@ class NeedLLMAdapter:
     COMBINED_RESOLUTION_TOOLS: List[Dict] = []  # populated after class body
 
     def __init__(self) -> None:
-        self._api_key: Optional[str] = os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("EMERGENT_LLM_KEY")
+        self._api_key: Optional[str] = next(
+            (os.environ[k] for k in (
+                "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY",
+                "OPENAI_API_KEY", "GEMINI_API_KEY", "EMERGENT_LLM_KEY",
+            ) if os.environ.get(k)),
+            None,
+        )
         self._model: str = os.environ.get("LLM_MODEL", "claude-sonnet-4-5-20250929")
-        if self._api_key and not os.environ.get("ANTHROPIC_API_KEY"):
-            os.environ["ANTHROPIC_API_KEY"] = self._api_key
+        # Emergent key is Anthropic-compatible; map it so LiteLLM finds it.
+        if os.environ.get("EMERGENT_LLM_KEY") and not os.environ.get("ANTHROPIC_API_KEY"):
+            os.environ["ANTHROPIC_API_KEY"] = os.environ["EMERGENT_LLM_KEY"]
 
     # ── Tool-calling loop ─────────────────────────────────────────────────────
 

--- a/serve-onboarding-agent-service/app/service/llm_adapter.py
+++ b/serve-onboarding-agent-service/app/service/llm_adapter.py
@@ -17,9 +17,14 @@ from dotenv import load_dotenv
 load_dotenv()
 logger = logging.getLogger(__name__)
 
-_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "") or os.environ.get("EMERGENT_LLM_KEY", "")
-if _API_KEY and not os.environ.get("ANTHROPIC_API_KEY"):
-    os.environ["ANTHROPIC_API_KEY"] = _API_KEY
+_PROVIDER_KEY_VARS = (
+    "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY",
+    "OPENAI_API_KEY", "GEMINI_API_KEY", "EMERGENT_LLM_KEY",
+)
+_API_KEY = next((os.environ[k] for k in _PROVIDER_KEY_VARS if os.environ.get(k)), "")
+# Emergent key is Anthropic-compatible; map it so LiteLLM finds it.
+if os.environ.get("EMERGENT_LLM_KEY") and not os.environ.get("ANTHROPIC_API_KEY"):
+    os.environ["ANTHROPIC_API_KEY"] = os.environ["EMERGENT_LLM_KEY"]
 _MODEL = os.environ.get("LLM_MODEL", "claude-haiku-4-5-20251001")
 _TIMEOUT = float(os.environ.get("LLM_TIMEOUT", "15"))
 

--- a/serve-orchestrator/app/service/persona_resolver.py
+++ b/serve-orchestrator/app/service/persona_resolver.py
@@ -55,9 +55,14 @@ _INACTIVE_THRESHOLD_DAYS = 90
 
 
 # ── LLM classifier config ──────────────────────────────────────────────────────
-_LLM_API_KEY = os.environ.get("ANTHROPIC_API_KEY", "") or os.environ.get("EMERGENT_LLM_KEY", "")
-if _LLM_API_KEY and not os.environ.get("ANTHROPIC_API_KEY"):
-    os.environ["ANTHROPIC_API_KEY"] = _LLM_API_KEY
+_PROVIDER_KEY_VARS = (
+    "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY",
+    "OPENAI_API_KEY", "GEMINI_API_KEY", "EMERGENT_LLM_KEY",
+)
+_LLM_API_KEY = next((os.environ[k] for k in _PROVIDER_KEY_VARS if os.environ.get(k)), "")
+# Emergent key is Anthropic-compatible; map it so LiteLLM finds it.
+if os.environ.get("EMERGENT_LLM_KEY") and not os.environ.get("ANTHROPIC_API_KEY"):
+    os.environ["ANTHROPIC_API_KEY"] = os.environ["EMERGENT_LLM_KEY"]
 _LLM_MODEL = os.environ.get("PERSONA_LLM_MODEL", "claude-haiku-4-5-20251001")
 _LLM_TIMEOUT = float(os.environ.get("PERSONA_LLM_TIMEOUT", "5"))
 _LLM_MIN_CONFIDENCE = 0.6  # Ignore LLM result below this threshold

--- a/serve-selection-agent-service/app/service/llm_adapter.py
+++ b/serve-selection-agent-service/app/service/llm_adapter.py
@@ -145,13 +145,17 @@ class SelectionLLMAdapter:
     """Natural LLM conversation adapter for selection. Model-agnostic via LiteLLM."""
 
     def __init__(self) -> None:
-        self._api_key: Optional[str] = (
-            os.environ.get("ANTHROPIC_API_KEY") or os.environ.get("EMERGENT_LLM_KEY")
+        self._api_key: Optional[str] = next(
+            (os.environ[k] for k in (
+                "ANTHROPIC_API_KEY", "OPENROUTER_API_KEY",
+                "OPENAI_API_KEY", "GEMINI_API_KEY", "EMERGENT_LLM_KEY",
+            ) if os.environ.get(k)),
+            None,
         )
         self._model: str = os.environ.get("LLM_MODEL", "claude-sonnet-4-5-20250929")
-        # Set API key for LiteLLM
-        if self._api_key and not os.environ.get("ANTHROPIC_API_KEY"):
-            os.environ["ANTHROPIC_API_KEY"] = self._api_key
+        # Emergent key is Anthropic-compatible; map it so LiteLLM finds it.
+        if os.environ.get("EMERGENT_LLM_KEY") and not os.environ.get("ANTHROPIC_API_KEY"):
+            os.environ["ANTHROPIC_API_KEY"] = os.environ["EMERGENT_LLM_KEY"]
 
     def build_system_prompt(
         self,


### PR DESCRIPTION
 ## Problem
  The services are model agnostic via LiteLLM and OpenAI/Gemini are listed as options, but non-Anthropic keys never worked. Two layers only handled Anthropic:
  - Every LiteLLM adapter only checked ANTHROPIC_API_KEY, so an OpenRouter/OpenAI/Gemini key was ignored, the LLM was never called, and a hardcoded fallback
  message was returned every turn while the state advanced silently. No error in logs or console.
  - docker-compose hardcoded the Claude model and forwarded only ANTHROPIC_API_KEY, so the container never saw the other key or model.

  ## Fix
  - Adapters now detect any known provider key (Anthropic, OpenRouter, OpenAI, Gemini, Emergent). The guard only confirms a key exists; LiteLLM picks the right
  one by the LLM_MODEL prefix.
  - Removed the blanket copy of any found key into ANTHROPIC_API_KEY (it misrouted non-Anthropic keys). Emergent key is still mapped to Anthropic since it is
  compatible.
  - docker-compose: LLM_MODEL now comes from env, and OPENROUTER_API_KEY / OPENAI_API_KEY / GEMINI_API_KEY are forwarded.

WHY:

Fixes #55 

  Files: onboarding, orchestrator persona_resolver, selection, fulfillment, engagement (x2), need adapters + docker-compose.yml.

  ## Not covered
  engagement_logic.py and memory_service.py call the Anthropic endpoint directly over httpx (not LiteLLM), so they remain Anthropic-only and need a separate
  change.

  ## Compatibility
  Anthropic users unaffected: set ANTHROPIC_API_KEY + a claude model as before. Anthropic is checked first and LiteLLM routes claude models to it.

  ## Testing
  Ran with LLM_MODEL=openrouter/meta-llama/llama-3.3-70b-instruct + an OpenRouter key. A multi-turn volunteer chat returned real, varied replies and advanced
  through stages (welcome → orientation_video, greeted the volunteer by name) instead of repeating the welcome message.